### PR TITLE
Allows ViewModel properties to be assigned by any assignable type

### DIFF
--- a/MiniVVM.Core/ViewFactory.cs
+++ b/MiniVVM.Core/ViewFactory.cs
@@ -70,7 +70,7 @@ namespace MiniVVM
                     continue;
 
                 var val = data[key];
-                if (property.PropertyType == val.GetType())
+                if (property.PropertyType.GetTypeInfo().IsAssignableFrom(val.GetType().GetTypeInfo()))
                 {
                     property.SetValue(viewModel, val);
                 }


### PR DESCRIPTION
This will allow non-equivalent generic types, subtypes and interfaces to be used to populate properties on the target ViewModel, so long as they are assignable from the provided value.
